### PR TITLE
Allow unquoted boolean attribute values

### DIFF
--- a/src/grammar.ne
+++ b/src/grammar.ne
@@ -33,6 +33,12 @@
     }
     return parsed
   }
+
+  const parseAsBoolean = (d, i, reject) => {
+    if (d[0] === 'true') return true;
+    if (d[0] === 'false') return false;
+    return reject;
+  }
 %}
 
 combinator ->
@@ -104,6 +110,8 @@ attributeValue ->
 floatOrInt ->
   int "." int {% parseAsNumber %}
   | int {% parseAsNumber %}
+  | "false" {% parseAsBoolean %}
+  | "true" {% parseAsBoolean %}
 
 int -> [0-9]:+
 

--- a/test/selectors/attributeValueSelector.js
+++ b/test/selectors/attributeValueSelector.js
@@ -80,3 +80,23 @@ for (const invalidAttributeValue of invalidAttributeValues) {
     });
   });
 }
+
+for (const booleanValue of [true, false]) {
+  test('valid attribute boolean value: [foo=' + String(booleanValue) + ']', (t): void => {
+    const tokens = parse('[foo=' + String(booleanValue) + ']');
+
+    if (tokens[0].type !== 'selector') {
+      throw new Error('Unexpected state.');
+    }
+
+    t.deepEqual(
+      tokens[0].body[0],
+      {
+        name: 'foo',
+        operator: '=',
+        type: 'attributeValueSelector',
+        value: booleanValue
+      }
+    );
+  });
+}


### PR DESCRIPTION
Allows `[foo=true]` and `[foo=false]`