### PR TITLE
Add parens in type selector

### DIFF
--- a/src/grammar.ne
+++ b/src/grammar.ne
@@ -71,7 +71,7 @@ typeSelector -> attributeName {% d => ({type: 'typeSelector', name: d[0]}) %}
 # see http://stackoverflow.com/a/449000/368691
 className -> "-":? [_a-zA-Z] [_a-zA-Z0-9-]:* {% d => (d[0] || '') + d[1] + d[2].join('') %}
 
-attributeName -> [_a-zA-Z] [_a-zA-Z0-9-]:* {% d => d[0] + d[1].join('') %}
+attributeName -> [_a-z()A-Z] [_a-zA-Z()0-9-]:* {% d => d[0] + d[1].join('') %}
 
 classSelector -> "." className {% d => ({type: 'classSelector', name: d[1]}) %}
 

--- a/test/selectors/typeSelector.js
+++ b/test/selectors/typeSelector.js
@@ -11,7 +11,9 @@ const validNodeNames = [
   'FOO',
   'foo-bar',
   '_0',
-  'foo-123'
+  'foo-123',
+  'foo(bar)',
+  'foo(bar(baz(qux)))'
 ];
 
 for (const validNodeName of validNodeNames) {


### PR DESCRIPTION
This is required to support querying components that may be wrapped in higher-order-components since the convention is to always wrap the displayName.

This change just allows parens anywhere in the selector. It doesn't enforce that they must be balanced or anything. We can adjust it if that's important.

Fixes https://github.com/airbnb/enzyme/issues/1124

cc @lelandrichardson