### PR TITLE
Remove engines field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,6 @@
     "semantic-release": "^6.3.2",
     "webpack": "^2.2.0"
   },
-  "engines": {
-    "node": ">=5"
-  },
   "keywords": [
     "css",
     "selector",


### PR DESCRIPTION
I verified the test suite passes all the way back to 0.12, so I don't think there's any reason to enforce this at all.