### PR TITLE
Allow arbitrary leading hyphens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "scalpel",
-  "version": "2.2.0",
+  "version": "2.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -48,5 +48,5 @@
     "precommit": "npm run lint && npm run test",
     "test": "ava --verbose"
   },
-  "version": "2.2.2"
+  "version": "2.2.3"
 }

--- a/package.json
+++ b/package.json
@@ -48,5 +48,5 @@
     "precommit": "npm run lint && npm run test",
     "test": "ava --verbose"
   },
-  "version": "2.2.3"
+  "version": "2.2.4"
 }

--- a/src/grammar.ne
+++ b/src/grammar.ne
@@ -8,6 +8,10 @@
     return flattenDeep(d);
   };
 
+  const flatJoin = d => {
+    return flatten(d).join('');
+  }
+
   const combinatorMap = {
     ' ': 'descendantCombinator',
     '+': 'adjacentSiblingCombinator',
@@ -68,10 +72,12 @@ simpleSelector ->
 
 typeSelector -> attributeName {% d => ({type: 'typeSelector', name: d[0]}) %}
 
-# see http://stackoverflow.com/a/449000/368691
-className -> "-":? [_a-zA-Z] [_a-zA-Z0-9-]:* {% d => (d[0] || '') + d[1] + d[2].join('') %}
 
-attributeName -> [_a-z()A-Z] [_a-zA-Z()0-9-]:* {% d => d[0] + d[1].join('') %}
+
+# see http://stackoverflow.com/a/449000/368691
+className -> [-]:* [_a-zA-Z] [_a-zA-Z0-9-]:* {% flatJoin %}
+
+attributeName -> [-]:* [_a-z()A-Z] [_a-zA-Z()0-9-]:* {% flatJoin %}
 
 classSelector -> "." className {% d => ({type: 'classSelector', name: d[1]}) %}
 

--- a/test/selectors/classSelector.js
+++ b/test/selectors/classSelector.js
@@ -9,6 +9,7 @@ const validClassNames = [
   'foo',
   'FOO',
   '-foo',
+  '--foo',
   '-_foo',
   '_0',
   'foo-0'

--- a/test/selectors/idSelector.js
+++ b/test/selectors/idSelector.js
@@ -9,7 +9,9 @@ const validIdNames = [
   'foo',
   'FOO',
   '_0',
-  'foo-0'
+  'foo-0',
+  '-foo',
+  '--foo'
 ];
 
 for (const validIdName of validIdNames) {
@@ -31,7 +33,6 @@ for (const validIdName of validIdNames) {
 }
 
 const invalidIdNames = [
-  '-foo',
   '123'
 ];
 

--- a/test/selectors/typeSelector.js
+++ b/test/selectors/typeSelector.js
@@ -13,7 +13,8 @@ const validNodeNames = [
   '_0',
   'foo-123',
   'foo(bar)',
-  'foo(bar(baz(qux)))'
+  'foo(bar(baz(qux)))',
+  '-foo'
 ];
 
 for (const validNodeName of validNodeNames) {
@@ -35,7 +36,6 @@ for (const validNodeName of validNodeNames) {
 }
 
 const invalidNodeNames = [
-  '-foo',
   '123'
 ];
 

--- a/test/sequences.js
+++ b/test/sequences.js
@@ -110,6 +110,10 @@ const validSelectors = {
     'qux0',
     'qux1'
   ],
+  'foo#--bar': [
+    'foo',
+    '--bar'
+  ],
   'foo#bar': [
     'foo',
     'bar'
@@ -146,6 +150,10 @@ const validSelectors = {
     'qux',
     'corge',
     'grault'
+  ],
+  'foo.--bar': [
+    'foo',
+    '--bar'
   ],
   'foo.baz': [
     'foo',


### PR DESCRIPTION
I don't think this is spec compliant, but Chrome's `querySelector` implementation also allows leading hyphens so we might as well support it because people are using it.

Resolves https://github.com/airbnb/enzyme/issues/1339