### PR TITLE
Allow escape sequence in class name grammar

### DIFF
--- a/src/grammar.ne
+++ b/src/grammar.ne
@@ -74,8 +74,9 @@ typeSelector -> attributeName {% d => ({type: 'typeSelector', name: d[0]}) %}
 
 # special characters used in css syntax, see https://mathiasbynens.be/notes/css-escapes
 # for these special characters we must add "\\" to escape it in class selector, or `document.querySelector` will throw
-specialChar -> [\u0021-\u002f\u003a-\u0040\u005b-\u005e\u0060\u007b-\u007e]  #"\\" | "!" | "#" | "$" | "%" | "&" | "'" | "(" | ")" | "[" | "]" | "*" | "+" | "," | "." | "/" | ":" | ";" | "<" | "=" | ">" | "?" | "@" | "^" | "`" | "{" | "|" | "}" | "~"
+specialChar -> "\\" | "!" | "#" | "$" | "%" | "&" | "'" | "(" | ")" | "[" | "]" | "*" | "+" | "," | "." | "/" | ":" | ";" | "<" | "=" | ">" | "?" | "@" | "^" | "`" | "{" | "|" | "}" | "~"
 # nonSpecialChar cannot repeated with [_a-zA-Z0-9-] or will get ambiguous when parsing className
+# write special char in unicode form so we don't need to handle escape in charset
 nonSpecialChar -> [^_a-zA-Z0-9-\u0021-\u002f\u003a-\u0040\u005b-\u005e\u0060\u007b-\u007e]
 
 # see https://drafts.csswg.org/css-syntax-3/#escaping

--- a/src/grammar.ne
+++ b/src/grammar.ne
@@ -72,10 +72,16 @@ simpleSelector ->
 
 typeSelector -> attributeName {% d => ({type: 'typeSelector', name: d[0]}) %}
 
+# special characters used in css syntax, see https://mathiasbynens.be/notes/css-escapes
+# for these special characters we must add "\\" to escape it in class selector, or `document.querySelector` will throw
+specialChar -> "\\" | "!" | "#" | "$" | "%" | "&" | "'" | "(" | ")" | "[" | "]" | "*" | "+" | "," | "." | "/" | ":" | ";" | "<" | "=" | ">" | "?" | "@" | "^" | "`" | "{" | "|" | "}" | "~"
 
+# see https://drafts.csswg.org/css-syntax-3/#escaping
+# now we only support special char escaping, not handling all unicode point and hex digit escape sequence
+escape -> "\\" specialChar
 
 # see http://stackoverflow.com/a/449000/368691
-className -> [-]:* [_a-zA-Z] [_a-zA-Z0-9-]:* {% flatJoin %}
+className -> [-]:* ([_a-zA-Z] | escape) ([_a-zA-Z0-9-] | escape):* {% flatJoin %}
 
 attributeName -> [-]:* [_a-z()A-Z] [_a-zA-Z()0-9-]:* {% flatJoin %}
 

--- a/src/grammar.ne
+++ b/src/grammar.ne
@@ -74,11 +74,15 @@ typeSelector -> attributeName {% d => ({type: 'typeSelector', name: d[0]}) %}
 
 # special characters used in css syntax, see https://mathiasbynens.be/notes/css-escapes
 # for these special characters we must add "\\" to escape it in class selector, or `document.querySelector` will throw
-specialChar -> "\\" | "!" | "#" | "$" | "%" | "&" | "'" | "(" | ")" | "[" | "]" | "*" | "+" | "," | "." | "/" | ":" | ";" | "<" | "=" | ">" | "?" | "@" | "^" | "`" | "{" | "|" | "}" | "~"
+specialChar -> [\u0021-\u002f\u003a-\u0040\u005b-\u005e\u0060\u007b-\u007e]  #"\\" | "!" | "#" | "$" | "%" | "&" | "'" | "(" | ")" | "[" | "]" | "*" | "+" | "," | "." | "/" | ":" | ";" | "<" | "=" | ">" | "?" | "@" | "^" | "`" | "{" | "|" | "}" | "~"
+# nonSpecialChar cannot repeated with [_a-zA-Z0-9-] or will get ambiguous when parsing className
+nonSpecialChar -> [^_a-zA-Z0-9-\u0021-\u002f\u003a-\u0040\u005b-\u005e\u0060\u007b-\u007e]
 
 # see https://drafts.csswg.org/css-syntax-3/#escaping
-# now we only support special char escaping, not handling all unicode point and hex digit escape sequence
-escape -> "\\" specialChar
+escape ->
+  "\\" specialChar |
+  # for non special unicode code point, the prefix backslash is optional
+  "\\":* nonSpecialChar
 
 # see http://stackoverflow.com/a/449000/368691
 className -> [-]:* ([_a-zA-Z] | escape) ([_a-zA-Z0-9-] | escape):* {% flatJoin %}

--- a/test/selectors/classSelector.js
+++ b/test/selectors/classSelector.js
@@ -12,7 +12,19 @@ const validClassNames = [
   '--foo',
   '-_foo',
   '_0',
-  'foo-0'
+  'foo-0',
+  '\\@',
+  'foo\\@0',
+  '-\\#a',
+  '\\\\',
+  '\\.',
+  '\\^',
+  '\\&',
+  '\\?',
+  '\\[',
+  '\\]',
+  '\\>',
+  '\\+'
 ];
 
 for (const validClassName of validClassNames) {
@@ -36,7 +48,8 @@ for (const validClassName of validClassNames) {
 const invalidClassNames = [
   '0',
   '-0',
-  '*'
+  '*',
+  'foo@0'
 ];
 
 for (const invalidClassName of invalidClassNames) {

--- a/test/selectors/classSelector.js
+++ b/test/selectors/classSelector.js
@@ -24,7 +24,10 @@ const validClassNames = [
   '\\[',
   '\\]',
   '\\>',
-  '\\+'
+  '\\+',
+  '±',
+  '\\±',
+  'foo_±\\@'
 ];
 
 for (const validClassName of validClassNames) {


### PR DESCRIPTION
Hi @aweary , I'm trying to work on airbnb/enzyme#1218, so I'd like to fix escape sequence parsing issue here at first.

According to [spec](https://drafts.csswg.org/css-syntax-3/#escaping), there are two ways to escape unicode code point:

1. backslash(\) + unicode code point without hex digit
2. backslash(\) + 1 to 6 hex digits + whitespace(optional)

I've finished (1). You could see it in the test. I'd go for (2) in the next few days.

Some interesting (?) issues I met when dealing with case (1):

(1) Though it's required to add the backslash to escape unicode code point, we can escape most of the unicode points without backslash in browser. When calling `document.querySelector` browser(I've tested chrome/ff/safari) will only throw with using special characters like `@#$%^&*<>` without backslash. With other unicode points the backslash is optional. `.±` and `.\±` are all valid selectors. I have found these special characters in one [blog post](https://mathiasbynens.be/notes/css-escapes), not got them in the spec..

(2) I've tried to move negation of non-hex-digit(`g-zG-Z-_`) out of the `nonSpecialChar`, but if we did so nealey will parse ambiguously even for simple selector like `.foo`. Not sure how to fix this and currently including them into `nonSpecialChar` is a workaround.

